### PR TITLE
Feature/sequence refactor

### DIFF
--- a/src/iptools/__init__.py
+++ b/src/iptools/__init__.py
@@ -447,6 +447,21 @@ class IpRange (Sequence):
         return self._len
     #end __len__
 
+    def __hash__ (self):
+        """
+        >>> a = IpRange('127.0.0.0/8')
+        >>> b = IpRange('127.0.0.0', '127.255.255.255')
+        >>> a.__hash__() == b.__hash__()
+        True
+        >>> c = IpRange('10/8')
+        >>> a.__hash__() == c.__hash__()
+        False
+        >>> b.__hash__() == c.__hash__()
+        False
+        """
+        return hash((self.startIp, self.endIp))
+    #end __hash__
+
     def _cast (self, item):
         if isinstance(item, basestring):
             item = ip2long(item)


### PR DESCRIPTION
Add more full featured `Sequence` support to IpRange:
- `__eq__()`
- `__hash__()`
- `index()`
- `__getitem__()`
- `count()`

Extension of `Sequence` needs to be conditional because python <2.6 doesn't have the abc base classes.

Changes allow using an IpRange in a wider variety of situations than the initial `for x in ...` use case.
