### PR TITLE
Remove extraneous #!/usr/bin/env python from library files

### DIFF
--- a/iptools/__init__.py
+++ b/iptools/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2008-2013, Bryan Davis

--- a/iptools/ipv4.py
+++ b/iptools/ipv4.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2008-2013, Bryan Davis

--- a/iptools/ipv6.py
+++ b/iptools/ipv6.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2008-2013, Bryan Davis


### PR DESCRIPTION
Library files are not meant to be executed directly and so the #! is unneeded (and triggers a rpmlint error).
