### PR TITLE
MANIFEST.in: add entire docs folder (not just rst)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ include LICENSE
 include MANIFEST.in
 include README.md
 recursive-include docs *
+recursive-exclude docs/_build
 prune docs/_build


### PR DESCRIPTION
When a release gets created the docs folder is missing the sphinx Makefile, config, static, and template folders which means it's not possible to build the docs with sphinx. This patch adds the missing pieces.
