### PR TITLE
fix: raise clear TypeError for non-int in long2ip()

### DIFF
--- a/iptools/ipv4.py
+++ b/iptools/ipv4.py
@@ -445,7 +445,7 @@ def long2ip(l):
     :returns: Dotted-quad ip address (eg. '127.0.0.1').
     :raises: TypeError
     """
-    if MAX_IP < l or l < MIN_IP:
+    if not isinstance(l, int) or isinstance(l, bool) or MAX_IP < l or l < MIN_IP:
         raise TypeError(
             "expected int between %d and %d inclusive" % (MIN_IP, MAX_IP))
     return '%d.%d.%d.%d' % (


### PR DESCRIPTION
## Bug Fix

In Python 3, `long2ip(None)` raises:

```
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

This comes from the comparison `MAX_IP < l` failing when `l` is `None`.
The doctest (which was written for Python 2) expects:

```
TypeError: unsupported operand type(s) for >>: 'NoneType' and 'int'
```

In Python 2, `None < int` was valid (always False), so execution reached the `>>` bit-shift operator. In Python 3, the comparison itself raises `TypeError`.

## Fix

Added an explicit `isinstance` check before the comparison so that `None` and other non-integer inputs raise a consistent, clear `TypeError("expected int between 0 and 4294967295 inclusive")` — the same message already raised for out-of-range integers.